### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Once a connection as been created, use the `with-connection` macro to wrap clien
 
 ```clojure
 (require '[flux.core :as flux]
-          [flux.query :as q])
+         '[flux.query :as q])
 
 (flux/with-connection conn
     (flux/add [{:id 1} {:id 2}])


### PR DESCRIPTION
Inserted missing quote that caused `CompilerException java.lang.ClassNotFoundException: flux.query`